### PR TITLE
Add travis-ci configuration (closes #2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os:
+  - linux
+  - osx
+language: rust
+rust:
+  - nightly
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Windows builds require postgres to be installed, and I haven't bothered to set that up yet.