### PR TITLE
Remove bellhop-hook-email from bellhop-demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,6 @@ dependencies = [
  "bellhop 0.2.0",
  "bellhop-auth-dummy 0.2.0",
  "bellhop-auth-header 0.2.0",
- "bellhop-hook-email 0.2.0",
  "bellhop-hook-jenkins 0.2.0",
 ]
 

--- a/bellhop-demo/Cargo.toml
+++ b/bellhop-demo/Cargo.toml
@@ -13,4 +13,6 @@ bellhop = { path = "../bellhop", version = "0.2.0" }
 bellhop-auth-dummy = { path = "../bellhop-auth-dummy", version = "0.2.0" }
 bellhop-auth-header = { path = "../bellhop-auth-header", version = "0.2.0" }
 bellhop-hook-jenkins = { path = "../bellhop-hook-jenkins", version = "0.2.0" }
-bellhop-hook-email = { path = "../bellhop-hook-email", version = "0.2.0" }
+
+# Cannot depend on bellhop-hook-email until lettre 0.9 releases
+#bellhop-hook-email = { path = "../bellhop-hook-email", version = "0.2.0" }

--- a/bellhop-demo/src/main.rs
+++ b/bellhop-demo/src/main.rs
@@ -12,15 +12,13 @@ use bellhop_auth_dummy::Dummy;
 
 use bellhop_auth_header::Header;
 
-use bellhop_hook_email::Email;
-
 use bellhop_hook_jenkins::Jenkins;
 
 fn main() {
     Bellhop::default()
         .auth(Header) // Allow logging in based on the value of 'X-Bellhop-Email' header.
         .auth(Dummy) // Allow logging in with just an email address.
-        .hook(Email::new()) // Sends emails when a lease is close to expiring.
+        // .hook(Email::new()) // Sends emails when a lease is close to expiring.
         .hook(Jenkins) // Triggers a jenkins build on certain hook events.
         .start() // Start running the server.
 }


### PR DESCRIPTION
Can't publish a crate with a git dependency to crates.io